### PR TITLE
Fixed #15

### DIFF
--- a/Couple List/Info.plist
+++ b/Couple List/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.0</string>
+	<string>2.4.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -41,7 +41,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>38</string>
+	<string>39</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Couple List/Views/EditActivityViewController.swift
+++ b/Couple List/Views/EditActivityViewController.swift
@@ -113,7 +113,7 @@ class EditActivityViewController: UIViewController {
             self.activity = self.clEditableCard.activity
             self.activity.isDone = true
             
-            self.ref.child("lists/\(CL.shared.userSettings.listKey)/activities/\(self.activity.key)").updateChildValues(["title": self.activity.title, "description": self.activity.desc, "done": self.activity.isDone, "person": self.activity.person!, "lastEditor": Auth.auth().currentUser!.uid])
+            self.ref.child("lists/\(CL.shared.userSettings.listKey)/activities/\(self.activity.key)").updateChildValues(["title": self.activity.title, "description": self.activity.desc, "done": self.activity.isDone, "person": self.activity.person ?? nil, "lastEditor": Auth.auth().currentUser!.uid])
             
             self.delegate.activityWasEdited(self.activity)
             self.navigationController?.popViewController(animated: true)


### PR DESCRIPTION
Fixed crash caused by unwrapping of potentially nil object. For activities created before version 2.0.0, the app will no longer crash when completing the activity.